### PR TITLE
Added definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@ Also there are no formal rules, but we should try to be kind and funny.
 ## Licence
 
 ### Preamble
-*before this licence goes too far we want to ensure some fundamentals of an open-source licnese are maintained (if somobody want's to use it in the future)*
+*before this licence goes too far we want to ensure some fundamentals that open-source comunity managed to get (if somobody want's to use it int the future)*
 
-If you relase a project with this licence you **MUST** release the source code, everybody is free to make his own copy, modify it, and redestribuite **USING THE SAME LICENCE**     
+If you relase a project with this licence you **MUST** release the source code, everybody is free to make his own copy, modify it, ad redestribuite **USING THE SAME LICENCE**     
+
+### From this moment forth:
+
+
+1. One shall refer to this document as the "Hobest's Word". (/hoʊbIst's Wɜːrd/    Hoa-BeSTs-WurD).
+
+2. One shall refer to the creator, author, and enforcer of this document (and the writings contained within) as the "Hobest" (/hoʊbIst/    Hoa-BeST).
+
+3. One shall refer to the actions, governance, elements of control, or elements under control of governance as the "commandments".
+
+4. One shall refer to all those who heed Hobest's word as the "Followers" of Hobest.
+
+5. One shall refer to all those who deny of the word of the Hobest as "FakeNews". 
+
+6. the "Elders" refers to the few maintainers, upholders, and aposties who found themselves closest to Hobest. The Elders are defined by the Hobest's Words "maintainers".
+
+7. "Word" realignment shall refer to the adaptations of the Hobest's Word to best fit the changes of time and language. This includes, but is not limited to, alterations to the commandments, the Hobest's word, and the scrolls of elder's.
+
+8. "Misinterpretation" are word realignments in which the word of Hobest is lost.
+
+9. "Messengers" refers to those followers of Hobest who have had a first hand experiance with Hobest and come to share his word. Sharing is done through the word realignent process.


### PR DESCRIPTION
Added some basic license definitions for later use in the license structure.

Here's a basic key for the definitions: 
1. Hobest's Word = License definition
2. Hobest = Licensor
3. commandments ~= legal entity
4. followers = users, contributors, etc... (you)
5. FakeNews = Anyone who doesn't use or respect the license.
6. elders = maintainers (HoraApps)
7. "word" realignment = pull requests 
8. Misinterpretation = pull requests that are denied by maintainers.
9. Messengers = contributors (successful pull requests)